### PR TITLE
Switched Event to Ensure Compatibiliy With Lesti_Fpc

### DIFF
--- a/app/code/local/Atwix/Ipstoreswitcher/Model/Observer.php
+++ b/app/code/local/Atwix/Ipstoreswitcher/Model/Observer.php
@@ -26,7 +26,7 @@ class Atwix_Ipstoreswitcher_Model_Observer
      * redirects customer to store view based on GeoIP
      * @param $event
      */
-    public function controllerActionPostdispatch($event)
+    public function controllerActionPredispatch($event)
     {
         $cookie = Mage::getSingleton('core/cookie');
         if ($cookie->get('geoip_processed') != 1) {

--- a/app/code/local/Atwix/Ipstoreswitcher/etc/config.xml
+++ b/app/code/local/Atwix/Ipstoreswitcher/etc/config.xml
@@ -41,14 +41,14 @@
     </global>
     <frontend>
         <events>
-            <controller_action_postdispatch>
+            <controller_action_predispatch>
                 <observers>
                     <atwix_ipstoreswitcher>
                         <class>atwix_ipstoreswitcher/observer</class>
-                        <method>controllerActionPostdispatch</method>
+                        <method>controllerActionPredispatch</method>
                     </atwix_ipstoreswitcher>
                 </observers>
-            </controller_action_postdispatch>
+            </controller_action_predispatch>
         </events>
     </frontend>
 </config>


### PR DESCRIPTION
Using `controller_action_postdispatch` will not work if using Lesti_Fpc. Lesti_Fpc will get the request and send a response before the Geo IP check is even executed. Using `controller_action_predispatch` solves this issue.
